### PR TITLE
Add new dependencies to requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+database.db
+
 # Created by https://www.toptal.com/developers/gitignore/api/flask,python,macos,windows,linux
 # Edit at https://www.toptal.com/developers/gitignore?templates=flask,python,macos,windows,linux
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ Flask-SQLAlchemy
 Flask-Migrate
 flask_seeder
 pyserial
+WTForms
+Flask-WTF


### PR DESCRIPTION
During https://github.com/ZYostSass/EPL-Card-Reader-Interface/pull/81 two new dependencies where added that did not end up in the requirements.txt file. I did not catch this error during my review. This PR fixes that problem.